### PR TITLE
E levels fix

### DIFF
--- a/qrotor/solve.py
+++ b/qrotor/solve.py
@@ -227,7 +227,7 @@ def E_levels(eigenvalues, vmax:float=None) -> list:
             levels, degeneracy = _get_E_levels_by_gap(eigenvalues, scale)
             if (degeneracy > 1) and (degeneracy % 1 == 0):
                 break
-    if not (degeneracy > 1) and not (degeneracy % 1) == 0:
+    if not (degeneracy > 1) or not (degeneracy % 1) == 0:
         return levels, degeneracy  # I give up
     # Correct the last two levels
     if len(levels) >= 2 and len(levels[-2]) != degeneracy:

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -26,3 +26,18 @@ def test_solve_potential():
     system.solve_potential()
     assert round(system.potential_max, 2) == 1.0
 
+def test_degeneracy_fail_point():
+    import numpy as np
+    from qrotor.system import System
+    degrees = np.arange(0, 360, 10)
+    energies = (1-np.cos(3*np.radians(degrees - 30.)))*2 + np.sin(20*np.radians(degrees - 30.))
+    energies -= np.min(energies)
+    system = System()
+    positions = np.radians(degrees)
+    potentials = np.array(energies) * 1000
+    system.grid = np.array(positions)
+    system.gridsize = len(positions)
+    system.potential_values = np.array(potentials)
+    system.searched_E = 400
+    system.solve(500)
+


### PR DESCRIPTION
Fix for issue described in #2 

Adds a test that fails with previous version but passes with the change made to `solve.E_levels`.

Ran the pre-existing tests with `pytest` and all (except for `test_rotation.py`, which failed before I made any changes) still pass